### PR TITLE
Fix: Add platform detection for Apple m1 chips

### DIFF
--- a/lib/k6/target.ex
+++ b/lib/k6/target.ex
@@ -57,6 +57,7 @@ defmodule K6.Target do
     case {architecture(), :os.type()} do
       {'x86_64', {:unix, :darwin}} -> {:x86, :darwin}
       {'arm', {:unix, :darwin}} -> {:arm, :darwin}
+      {'aarch64', {:unix, :darwin}} -> {:arm, :darwin}
       {'x86_64', {:unix, :linux}} -> {:x86, :linux}
       {'arm', {:unix, :linux}} -> {:arm, :linux}
     end


### PR DESCRIPTION
Added a mapping from 'aarch64' architecture to`{:arm, :darwin}`. This works because the Apple M1 chip works with the macos-arm64 binaries.

I have tested it on my m1 and this works as expected.