### PR TITLE
Add getParams parameter for LiveView connect function

### DIFF
--- a/priv/templates/utilities/phoenix-liveview.js
+++ b/priv/templates/utilities/phoenix-liveview.js
@@ -11,8 +11,8 @@ export default class Liveview {
     this.params = params;
   }
 
-  connect(callback, parseBody = this._parseBody) {
-    let response = http.get(this.url.toString());
+  connect(callback, getParams = null, parseBody = this._parseBody) {
+    let response = http.get(this.url.toString(), getParams);
     let { csrfToken, phxId, phxSession, phxStatic } = parseBody(
       response.body
     );


### PR DESCRIPTION
To establish a LiveView connection, the initial page must be loaded.
With this PR, it is possible to pass a parameter containing the parameters
for this get request (e.g. cookies) to the connect function.

This fixes #4!